### PR TITLE
Fixes to bugs and -jcalc capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ mrweprefs.r
 project.r
 absoft_run_env.sh
 Release
+AWE_Preferences.f95
 
 
 # Ignore Mac OS X system files

--- a/CMS_Files/CMS.h
+++ b/CMS_Files/CMS.h
@@ -6,7 +6,7 @@ c     Set array dimensions
      3        MAX_ATTEN, MAX_ATTENTYPE, MAX_BR, MAX_NODE
       integer MAX_Med, MAX_epistemic, MAX_sigma, MAX_SYN
 
-      PARAMETER ( MAX_SITE  = 1, MAX_FLT = 150, MAX_SEG  = 10,
+      PARAMETER ( MAX_SITE  = 1, MAX_FLT = 160, MAX_SEG  = 10,
      1            MAX_INTEN = 30, MAX_PROB = 20, MAX_DIP=5,
      2            MAXPARAM = 200, MAX_MAG=15, MAX_DIST=15,
      3            MAX_EPS=15, MAX_N1=150, MAX_Files=3, MAX_N2=6,MAX_Xcost=10,

--- a/CMS_Files/calc_cms.f
+++ b/CMS_Files/calc_cms.f
@@ -4,12 +4,14 @@
 
       implicit none
       include 'cms.h'
-      real period(MAX_PROB), med(MAX_PROB), sig(MAX_PROB), shape(MAX_PROB),UHS1(MAX_PROB)
-      real Tprime(MAX_PROB), T_max, T_min, c1, c2, c3, c4
-      real rho(MAX_PROB),epsilon_bar(MAX_PROB), UHS2(MAX_PROB), period5(MAX_PROB)
-      real Tstar, temp, epsilonstar, cms(MAX_PROB)
-      real pi, Tamp15,t1, Trockratio, Tstarprime, SaTstarprime, medTstarprime, sigTstarprime, eps_bar_TSP
-      integer iScen, nScenario, iPer2, nProb, iFlag, iPer, j, RefPt, i
+      
+      integer iScen, nScenario, iPer2, nProb, iFlag, iPer, i
+      real period(MAX_PROB), med(MAX_PROB), sig(MAX_PROB), Tstarprime, 
+     1     Tprime(MAX_PROB), T_max, T_min, c1, c2, c3, c4, rho(MAX_PROB),
+     2     epsilon_bar(MAX_PROB), UHS2(MAX_PROB), period5(MAX_PROB), Tstar, 
+     3     temp, epsilonstar, cms(MAX_PROB), pi, Tamp15, t1, Trockratio, 
+     4     shape(MAX_PROB), UHS1(MAX_PROB)
+
       pi =3.1415926
 
 c     Copy UHS to new array (this new one will be shifted)    

--- a/CMS_Files/cms_main.f
+++ b/CMS_Files/cms_main.f
@@ -59,7 +59,7 @@ c     for HAZ45 IO subroutine
 c     Read the hazard run file to get the logic tree weights for the GMPEs 
 c     and the testInten values
       call RdInput (nInten, testInten, nGM_model, nattentype,attenType,
-     1               nProb, GM_wt, period, jCalc, gm_scale, VarAdd, version)
+     1               nProb, GM_wt, period, jCalc, gmscale, VarAdd, version)
        
 c     Read the out6 file
       write (*,'( 2x,''reading logic tree file out6'')')

--- a/CMS_Files/cms_main.f
+++ b/CMS_Files/cms_main.f
@@ -1,10 +1,10 @@
       program CMS_Haz45
 
 c     This program will compute the conditional mean spectra for conditioning periods
-c     from PSHA runs. This version is compatible with the output files from Haz45.2
+c     from PSHA runs. This version is compatible with the output files from Haz45.3
 c     which only outputs the mean hazard code combined over all attenuation models. 
 
-c     Version 45.2, last modified 04/2017
+c     Version 45.3
 
       implicit none
       include 'cms.h'
@@ -30,9 +30,9 @@ c     Version 45.2, last modified 04/2017
       character*80 filein, file1, dummy, attenName(4,MAX_ATTEN), sigmaName(4,MAX_ATTEN)
                   
       write (*,*) '******************************'
-      write (*,*) '*      CMS Code for GMC      *'
-      write (*,*) '*  compatible with Haz45.2   *'
-      write (*,*) '*   Tagged April 10, 2017    *'
+      write (*,*) '*   CMS Code: Version 45.3   *'
+      write (*,*) '*      Under Development     *'
+      write (*,*) '*      September, 2018       *'
       write (*,*) '******************************'
 
       write (*,*) 'Enter the input filename.'
@@ -63,7 +63,7 @@ c     Open the output file
       read (31,'( a80)') file1
       open (50,file=file1,status='new')
       write (50,*) ' *** Output file from program CMS  *** '
-      write (50,*) '        *** Version 45.2 ***           '    
+      write (50,*) '        *** Version 45.3 ***           '    
       write (50,*) 
       write (50,'(a17,2x,a80)') ' Input filename: ', filein 
       write (50,*) 

--- a/CMS_Files/cms_main.f
+++ b/CMS_Files/cms_main.f
@@ -1,47 +1,33 @@
       program CMS_Haz45
 
-C     This program will compute the conditional mean spectra for conditioning periods
-C     from PSHA runs. This version is compatible with the output files from Haz45.2
+c     This program will compute the conditional mean spectra for conditioning periods
+c     from PSHA runs. This version is compatible with the output files from Haz45.2
 c     which only outputs the mean hazard code combined over all attenuation models. 
 
-C     Version 45.2, last modified 04/2017
+c     Version 45.2, last modified 04/2017
 
       implicit none
       include 'cms.h'
       
       real*8 haz(MAX_PROB, MAX_ATTENTYPE, MAX_ATTEN, MAX_INTEN)
       real*8 hazmean1(MAX_ATTENTYPE,MAX_INTEN)      
-      
-      real version
-      real gm_Scale(MAX_PROB,4,MAX_ATTEN), varAdd(MAX_PROB,4,MAX_ATTEN)
-      real period(MAX_PROB), ratio
-      real lgInten,sigmaY
-      real sum, sum1, sum2
-      real period1(4,MAX_PROB), tau, phi
-      real hazLevel, haz_GMPE(MAX_INTEN), haz10
-      real wt_deagg (MAX_ATTENTYPE,MAX_ATTEN)
-      real UHS1(MAX_PROB), epsilonstar,rho, epsilon_bar, CMS(MAX_PROB)
-      real rRup, rJB, rSeismo, rHypo, Rx, Ry0, mag,
-     1        ftype, vs30, hypoDep, AR, dip, Z1, Z15, Z25, zTOR, 
-     2        theta_site, RupWidth
 
-      integer iPer, nAttenType
-      integer  HWFlag, vs30_class, forearc, nScenario, intflag(4,MAX_PROB), iScen
-      integer iInten, nProb, jProb
-      integer nGM_model(MAX_PROB,MAX_ATTENTYPE), jType, iAtten, kType
-      
+      integer iPer, nAttenType, HWFlag, vs30_class, forearc, nScenario, 
+     1        intflag(4,MAX_PROB), iScen, iInten, nProb, jProb, kType,
+     2        nGM_model(MAX_PROB,MAX_ATTENTYPE), jType, iAtten, iPer2, 
+     3        attenType(MAX_FLT), jCalc(MAX_PROB,4,MAX_ATTEN), nINten1, 
+     4        nInten(MAX_PROB)      
+      real version, varAdd(MAX_PROB,4,MAX_ATTEN), period(MAX_PROB), ratio,
+     1     lgInten, sigmaY, sum, sum1, sum2, wt_deagg(MAX_ATTENTYPE,MAX_ATTEN),
+     2     hazLevel, haz_GMPE(MAX_INTEN), haz10, period1(4,MAX_PROB), tau, phi,
+     3     UHS1(MAX_PROB), epsilonstar, CMS(MAX_PROB), rRup, rJB, rSeismo, 
+     4     rHypo, Rx, Ry0, mag, ftype, vs30, hypoDep, AR, dip, Z1, Z15, Z25, 
+     5     zTOR, theta_site, RupWidth, testInten(MAX_PROB, MAX_INTEN),
+     6     gmScale(MAX_PROB,4,MAX_ATTEN), gm_wt(MAX_PROB,4,MAX_ATTEN),
+     7     cfcoefrrup(MAX_Atten,11), cfcoefrjb(MAX_Atten,11), med(MAX_PROB), 
+     8     sig(MAX_PROB)      
       character*80 filein, file1, dummy, attenName(4,MAX_ATTEN)
-
-c     for HAZ45 IO subroutine
-      real testInten(MAX_PROB, MAX_INTEN)
-      real gmScale(MAX_PROB,4,MAX_ATTEN), gm_wt(MAX_PROB,4,MAX_ATTEN) 
-      real cfcoefrrup(MAX_Atten,11), cfcoefrjb(MAX_Atten,11)
-      real period2(MAX_PROB), med(MAX_PROB), sig(MAX_PROB)
-      integer attenType(MAX_FLT), nInten(MAX_PROB)
-      integer jCalc(MAX_PROB,4,MAX_ATTEN)
-      integer iPer2, nINten1
-            
-      
+                  
       write (*,*) '******************************'
       write (*,*) '*      CMS Code for GMC      *'
       write (*,*) '*  compatible with Haz45.2   *'
@@ -129,8 +115,6 @@ c        Write out the deagg wts
      1          ratio, gm_wt(iPer,jType,iAtten), wt_deagg(jType,iAtten)
         enddo
        enddo
-
-
        
 c      Compute the median and sigma for each GMPE for each scenario
        read (31,*,err=3000) nScenario
@@ -181,7 +165,7 @@ c        Write the deagg-weighted median and sigma for the scenario
 c      Write header for the CMS_part1  
        write (50,'( /,''    Period    UHS       Med       Sigma     Tamp15    Eps*      Rho       Eps_bar   CMS '' )') 
 
-C      Compute the CMS   
+c      Compute the CMS   
           call calcCMS ( med, sig, period, UHS1, epsilonstar, CMS,
      1                   iPer2, iPer, iScen, nScenario, nProb )
        enddo

--- a/CMS_Files/cms_main.f
+++ b/CMS_Files/cms_main.f
@@ -30,7 +30,7 @@ C     Version 45.2, last modified 04/2017
       integer iInten, nProb, jProb
       integer nGM_model(MAX_PROB,MAX_ATTENTYPE), jType, iAtten, kType
       
-      character*80 filein, file1, dummy, attenName(4,MAX_PROB)
+      character*80 filein, file1, dummy, attenName(4,MAX_ATTEN)
 
 c     for HAZ45 IO subroutine
       real testInten(MAX_PROB, MAX_INTEN)

--- a/CMS_Files/rd_flt.f
+++ b/CMS_Files/rd_flt.f
@@ -1,49 +1,36 @@
 
-
- 
-      subroutine Rd_Fault_Data  (nFltTotal, nFlt0, f_start, f_num, AttenType, 
-     1           n_Dip, n_bValue, nActRate,  nSR,   nRecInt,   nMoRate,   nMagRecur,  
-     1           nThick1,      nRefMag,  nFtypeModels,
-     2           dipWt, bValueWt, actRateWt, wt_sr, wt_recInt, wt_MoRate, magRecurWt, 
-     2           faultThickWt, refMagWt, ftmodelwt,
-     3           nFtype, ftype_wt1, wt_RateMethod, al_Segwt, 
-     4           nRate, rateType, nBR_SSC, nSegModel1, segwt1, segFlag, indexRate)
+      subroutine Rd_Fault_Data (nFltTotal, nFlt0, f_start, f_num, AttenType, 
+     1           n_Dip, n_bValue, nActRate, nSR, nRecInt, nMoRate, nMagRecur,  
+     2           nThick1, nRefMag, nFtypeModels, dipWt, bValueWt, actRateWt, 
+     3           wt_sr, wt_recInt, wt_MoRate, magRecurWt, faultThickWt, 
+     4           refMagWt, ftmodelwt, nFtype, ftype_wt1, wt_RateMethod, al_Segwt, 
+     5           nRate, rateType, nBR_SSC, nSegModel1, segwt1, segFlag, indexRate)
 
       implicit none
       include 'cms.h'
-      integer nSegModel1(MAX_FLT), segFlag(MAX_FLT, MAX_SEG), iSeg
-      real segwt1 (MAX_FLT,MAX_SEG)
-
-      integer nFltTotal, nFlt0, f_start(MAX_FLT), f_num(MAX_FLT)
-      integer faultflag(MAX_FLT,MAX_SEG,MAX_FLT), nBR_SSC(MAX_FLT,MAX_BR)
-
-      integer nSegModel(MAX_FLT), n_Dip(MAX_FLT),n_bvalue(MAX_FLT), nActRate(MAX_FLT), 
-     1        nSR(MAX_FLT), nRecInt(MAX_FLT), nMoRate(MAX_FLT)
-      integer nMagRecur(MAX_FLT), nThick1(MAX_FLT), nRefMag(MAX_FLT,MAX_WIDTH), nFtypeModels(MAX_FLT)
-      integer Attentype(MAX_FLT)
-      integer nFtype(MAX_FLT,MAXPARAM), rateType(MAX_FLT,MAXPARAM), Nrate(MAX_FLT)
-      integer indexrate(MAX_FLT,4)
-
-      real al_segWt(MAX_FLT)
-
-      real segwt(MAX_FLT,MAX_FLT), dipWt(MAX_FLT,MAXPARAM), bValueWt(MAX_FLT,MAXPARAM), actRateWt(MAX_FLT,MAXPARAM), 
-     1     wt_SR(MAX_FLT,MAXPARAM), wt_RecInt(MAX_FLT,MAXPARAM), wt_MoRate(MAX_FLT,MAXPARAM), magRecurWt(MAX_FLT,MAXPARAM),    
-     1     faultWidthWt(MAX_FLT,MAXPARAM),  faultThickWt(MAX_FLT,MAXPARAM), 
-     2     refMagWt(MAX_FLT,MAX_Width,MAXPARAM), ftmodelwt(MAX_FLT,MAXPARAM)
-      real wt_rateMethod(MAX_FLT,4)
-
-      real ftype_wt1(MAX_FLt,MAXPARAM,5)
-      real ftype1(10,10)
-
-      integer iCoor, nFLT2, iFlt, iFlt2, nsyn, nfp, iDepthModel, iOverRideMag
-      integer iFLt0, k, i, isourceType, insyn, synflag, directflag, ipt, nDownDip, ii
-      integer iRecur, iThick, iThick1, iFM
+      
+      integer nSegModel1(MAX_FLT), segFlag(MAX_FLT, MAX_SEG), iSeg, nFlt0, 
+     1        nFltTotal, f_start(MAX_FLT), f_num(MAX_FLT), nSegModel(MAX_FLT), 
+     2        faultflag(MAX_FLT,MAX_SEG,MAX_FLT), nBR_SSC(MAX_FLT,MAX_BR),
+     3        n_Dip(MAX_FLT), n_bvalue(MAX_FLT), nActRate(MAX_FLT), iRecur, 
+     4        nSR(MAX_FLT), nRecInt(MAX_FLT), nMoRate(MAX_FLT), Nrate(MAX_FLT),
+     5        nMagRecur(MAX_FLT), nThick1(MAX_FLT), nRefMag(MAX_FLT,MAX_WIDTH), 
+     6        nFtypeModels(MAX_FLT), Attentype(MAX_FLT), indexrate(MAX_FLT,4),
+     7        nFtype(MAX_FLT,MAXPARAM), rateType(MAX_FLT,MAXPARAM), ii, iThick, 
+     8        iCoor, nFLT2, iFlt, iFlt2, nsyn, nfp, iDepthModel, iOverRideMag,
+     9        iFLt0, k, i, isourceType, insyn, synflag, directflag, ipt, nDownDip, 
+     1        iThick1, iFM
+      real segwt1 (MAX_FLT,MAX_SEG), al_segWt(MAX_FLT), segwt(MAX_FLT,MAX_FLT), 
+     1     dipWt(MAX_FLT,MAXPARAM), bValueWt(MAX_FLT,MAXPARAM), actRateWt(MAX_FLT,MAXPARAM), 
+     2     wt_SR(MAX_FLT,MAXPARAM), wt_RecInt(MAX_FLT,MAXPARAM), wt_MoRate(MAX_FLT,MAXPARAM), 
+     3     magRecurWt(MAX_FLT,MAXPARAM), faultThickWt(MAX_FLT,MAXPARAM), probAct0, 
+     4     refMagWt(MAX_FLT,MAX_Width,MAXPARAM), ftmodelwt(MAX_FLT,MAXPARAM),
+     5     wt_rateMethod(MAX_FLT,4), ftype_wt1(MAX_FLt,MAXPARAM,5), ftype1(10,10),
+     6     flat, flong, fz, sampleStep, minmag, sigArea, sigWidth, magsyn, dip1, 
+     7     top, x(100), x2(100,100), bValue2, actRate 
       character*80 fName1, fName 
-      real flat, flong, fz, sampleStep, minmag, sigArea, sigWidth
-      real probAct0, magsyn, dip1, top, x(100), x2(100,100) 
-      real bValue2, actRate
 
-C     Input Fault Parameters
+c     Input Fault Parameters
       read (10,*) iCoor
       read (10,*) NFLT0
 
@@ -51,7 +38,7 @@ C     Input Fault Parameters
   
       iflt = 0
 
-C.....Loop over each fault in the source file....
+c     Loop over each fault in the source file....
       DO iFlt0=1,NFLT0
         read (10,'( a80)') fName1
         read (10,*) probAct0
@@ -71,7 +58,7 @@ c       This allows us to find the right fault from the large list
         f_start(iFlt0) = iFlt + 1
         f_num(iFlt0) = nFlt2 
 
-C.......Loop over number of individual fault segments....                        
+c       Loop over number of individual fault segments....                        
         do iflt2=1,nflt2
 
           iFlt = iFlt + 1
@@ -126,7 +113,7 @@ c           Read over grid filename...
 c         Check for custom fault source
           if ( isourceType .eq. 5) then
             read(10,*) nDownDip, nfp
-c........   Only read in the first downdip case - rest is not needed...
+c           Only read in the first downdip case - rest is not needed...
             do ipt=1,nfp
               read (10,*) fLong, fLat, fZ
             enddo
@@ -210,8 +197,6 @@ c         Read moment-rates
           indexRate(iFlt,2) = indexRate(iFlt,1) + nSR(iFlt)
           indexrate(iFlt,3) = indexRate(iFlt,2) + nActRate(iFlt)
           indexrate(iFlt,4) = indexRate(iFlt,3) + nRecInt(iFlt)
-
-
                                    
 c         Read Mag recurrence weights (char and exp)
           read (10,*) nMagRecur(iFlt)

--- a/CMS_Files/rd_input.f
+++ b/CMS_Files/rd_input.f
@@ -1,44 +1,22 @@
 c -------------------------------------------------------------------------
 
       subroutine RdInput (nInten,  testInten, nGM_model, nattentype,
-     1 attenType, nProb, gm_wt, period, jcalc, gm_scale, VarAdd, version)
+     1 attenType, nProb, gm_wt, period, jcalc, gm_scale, varadd, version)
 
+      implicit none
       include 'cms.h'
 
-      real version      
-      real testInten(MAX_PROB,MAX_INTEN)
-      real segModelWt(1), probAct(1), minlat,maxlat,minlong,maxlong,maxdist
-      integer nInten(MAX_PROB), ntotal, attentype(MAX_FLT)
-      integer iii
-      integer jCalc(MAX_PROB,4,MAX_ATTEN)
-      real gm_Scale(MAX_PROB,4,MAX_ATTEN), varAdd(MAX_PROB,4,MAX_ATTEN)
-
-      character*80 filein, title, fname(1), dummy
-      integer nfiles, ix(MAX_FILES)
-      integer nWidth(MAX_FLT)
-      real period(MAX_PROB)
-
-      integer nMagBins, nDistBins, nEpsBins, nXcostBins, soilampflag
-      real magBins(MAX_MAG), distBins(MAX_DIST), epsBins(MAX_EPS)
-      real XcostBins(MAX_XCOST)
-      integer nProb, nattentype, nGM_Model(MAX_PROB,MAX_ATTENTYPE)
-      real testwt, checkwt, c1, c2, gm_WT(MAX_PROB,4,MAX_ATTEN)
+      integer nProb, nattentype, nGM_Model(MAX_PROB,MAX_ATTENTYPE),
+     1        nInten(MAX_PROB), attentype(MAX_FLT), iprob, dirflag, j, 
+     2        jj, iMix(MAX_PROB,4,MAX_ATTEN), jcalc(MAX_PROB,4,MAX_ATTEN)
+      real version, specT, sigtrunc, testInten(MAX_PROB,MAX_INTEN),
+     1     minlat, maxlat, minlong, maxlong, maxdist, 
+     2     gm_scale(MAX_PROB,4,MAX_ATTEN), varadd(MAX_PROB,4,MAX_ATTEN),
+     3     checkwt, c1, c2, gm_wt(MAX_PROB,4,MAX_ATTEN), period(MAX_PROB)
+      character*80 filein, title
 
 c     For CMS, all we need is the logic tree weights for the GMPEs
 c     This will read past the inputs until it gets to the GMPE weights
-
-c     Set Data file units
-      nwr = 11
-
-      ntotal = 0
-
-c     Read in the number of data files.
-c      read (5,*) nfiles
-c     Program no longer allowed to read from multiple files.
-      nFiles = 1
-
-c     Loop over the number of files.
-c      do 111 iii=1,nfiles
 
 c     Open PSHA Run Input File
       read (31,'( a80)') filein
@@ -47,7 +25,6 @@ c     Open PSHA Run Input File
 
 c     Open Input PSHA Source/Fault file
       read (20,'( a80)') filein
-c      open (10,file=filein,status='old')
 
 c     Check for version compatibility with hazard code
         read (20,*) version
@@ -58,9 +35,9 @@ c     Check for version compatibility with hazard code
         endif
 
 c     Read in parameters for background grid.
-      read (20,*,ERR=2001) minlat,maxlat,minlong,maxlong
+      read (20,*,ERR=2001) minlat, maxlat, minlong, maxlong
 
-C     Added back in read of single maxdist
+c     Added back in read of single maxdist
       read (20,*,ERR=2002) maxdist
 
 c     Input Title (not used) 
@@ -68,18 +45,16 @@ c     Input Title (not used)
 
 c     Number of Spectral Periods and Number of attenuation relations types
       read(20,*,ERR=2003) nProb, nattentype
-c      write (*,'( 2i5)') nProb, nattentype
       
       do iprob=1,nProb
 
-C       Read period, maxeps dir flag and gm intensities
+c       Read period, maxeps dir flag and gm intensities
         read (20,*,ERR=2004) specT, sigtrunc, dirflag 
         read (20,*,ERR=2005) nInten(iProb), (testInten(iProb,j), j=1,nInten(iProb))
         call CheckDim ( nInten(iProb), MAX_INTEN, 'MAX_INTEN' )
         period(iProb) = specT
-x        write (*,'( i5,f10.3)') iProb, period(iProb)
 
-C       Read in the suite of attenution models and wts for each attentype
+c       Read in the suite of attenution models and wts for each attentype
         do j=1,nattentype
           checkwt = 0.0
           read (20,*,ERR=2006) nGM_model(iProb,j)
@@ -88,12 +63,11 @@ c         Check for Max number of attenuation model
           call checkDim ( nGM_model(iProb,j), MAX_ATTEN, 'MAX_ATTEN' )
 
           do jj=1,nGM_model(iProb,j)
-            read (20,*,ERR=2007) jcalc(iProb,j,jj), c1, c2, gm_wt(iProb,j,jj), Varadd1, iMix
+            read (20,*,ERR=2007) jcalc(iProb,j,jj), c1, c2, gm_wt(iProb,j,jj), varadd(iProb,j,jj), iMix(iProb,j,jj)
             gm_scale(iProb,j,jj) = c1 + c2
-            varAdd(iProb,j,jj) = varAdd1
-c            if ( jCalc(j,jj) .lt. 0 ) then
+c            if ( jcalc(j,jj) .lt. 0 ) then
 c               backspace (20)
-c               read (20,*) jcalc(j,jj), c1, c2, wtgm(j,jj), Varadd, sCalc(j,jj), sigfix(j,jj), sssCalc(j,jj)
+c               read (20,*) jcalc(j,jj), c1, c2, wtgm(j,jj), varadd, sCalc(j,jj), sigfix(j,jj), sssCalc(j,jj)
 c            endif
           enddo
         enddo

--- a/CMS_Files/rd_input.f
+++ b/CMS_Files/rd_input.f
@@ -31,9 +31,9 @@ c     Open Input PSHA Source/Fault file
 
 c     Check for version compatibility with hazard code
         read (20,*) version
-         if (version .ne. 45.2 .and. version .ne. 45.1) then
+         if (version .ne. 45.3 .and. version .ne. 45.2 .and. version .ne. 45.1) then
          write (*,*) version
-         write (*,*) 'Hazard faultfile format incompatible version of Haz45, use Haz45.2 or Haz45.1'
+         write (*,*) 'Hazard faultfile format incompatible version of Haz45, use Haz45.3 or Haz45.2 or Haz45.1'
          stop 99
         endif
 

--- a/CMS_Files/rd_input.f
+++ b/CMS_Files/rd_input.f
@@ -1,18 +1,21 @@
 c -------------------------------------------------------------------------
 
       subroutine RdInput (nInten,  testInten, nGM_model, nattentype,
-     1 attenType, nProb, gm_wt, period, jcalc, gm_scale, varadd, version)
+     1           attenType, nProb, gm_wt, period, jcalc, gm_scale, varadd, 
+     2           version, scalc, sigfix)
 
       implicit none
       include 'cms.h'
 
       integer nProb, nattentype, nGM_Model(MAX_PROB,MAX_ATTENTYPE),
      1        nInten(MAX_PROB), attentype(MAX_FLT), iprob, dirflag, j, 
-     2        jj, iMix(MAX_PROB,4,MAX_ATTEN), jcalc(MAX_PROB,4,MAX_ATTEN)
+     2        jj, iMix(MAX_PROB,4,MAX_ATTEN), jcalc(MAX_PROB,4,MAX_ATTEN),
+     3        scalc(MAX_PROB,4,MAX_ATTEN) 
       real version, specT, sigtrunc, testInten(MAX_PROB,MAX_INTEN),
      1     minlat, maxlat, minlong, maxlong, maxdist, 
      2     gm_scale(MAX_PROB,4,MAX_ATTEN), varadd(MAX_PROB,4,MAX_ATTEN),
-     3     checkwt, c1, c2, gm_wt(MAX_PROB,4,MAX_ATTEN), period(MAX_PROB)
+     3     checkwt, c1, c2, gm_wt(MAX_PROB,4,MAX_ATTEN), period(MAX_PROB),
+     4     sigfix(MAX_PROB,4,MAX_ATTEN)
       character*80 filein, title
 
 c     For CMS, all we need is the logic tree weights for the GMPEs
@@ -54,7 +57,7 @@ c       Read period, maxeps dir flag and gm intensities
         call CheckDim ( nInten(iProb), MAX_INTEN, 'MAX_INTEN' )
         period(iProb) = specT
 
-c       Read in the suite of attenution models and wts for each attentype
+c       Read in the suite of attenuation models and wts for each attentype
         do j=1,nattentype
           checkwt = 0.0
           read (20,*,ERR=2006) nGM_model(iProb,j)
@@ -64,11 +67,12 @@ c         Check for Max number of attenuation model
 
           do jj=1,nGM_model(iProb,j)
             read (20,*,ERR=2007) jcalc(iProb,j,jj), c1, c2, gm_wt(iProb,j,jj), varadd(iProb,j,jj), iMix(iProb,j,jj)
+            if ( jcalc(iProb,j,jj) .lt. 0 ) then
+              backspace (20)
+              read (20,*,ERR=2007) jcalc(iProb,j,jj), c1, c2, gm_wt(iProb,j,jj), varadd(iProb,j,jj), iMix(iProb,j,jj),
+     1              sCalc(iProb,j,jj), sigfix(iProb,j,jj)
+            endif
             gm_scale(iProb,j,jj) = c1 + c2
-c            if ( jcalc(j,jj) .lt. 0 ) then
-c               backspace (20)
-c               read (20,*) jcalc(j,jj), c1, c2, wtgm(j,jj), varadd, sCalc(j,jj), sigfix(j,jj), sssCalc(j,jj)
-c            endif
           enddo
         enddo
 

--- a/CMS_Files/rd_out3.f
+++ b/CMS_Files/rd_out3.f
@@ -1,26 +1,23 @@
       subroutine RdOut3 ( UHS1, hazLevel ) 
-c      implicit none
+
+      implicit none
       include 'cms.h'
 
+      integer nRd, nFlt, nProb, nAmp(MAX_PROB), j, l, idum, iProb, 
+     1        iAtten, iAmp, k, testnum
+      real lat, long, version, hazLevel, segModelwt(MAX_FLT), al_segwt(MAX_FLT),
+     1     mindist(MAX_FLT), x, UHS1(MAX_PROB), HazTotal(MAX_PROB,MAX_INTEN), 
+     2     amp(MAX_PROB,MAX_INTEN), mBar(MAX_PROB,MAX_INTEN), dBar(MAX_PROB,MAX_INTEN),
+     3     Haz(MAX_PROB,MAX_INTEN,MAX_FLT), eBar(MAX_PROB,MAX_INTEN), testHaz 
       character*80 file1, dummy, fname(MAX_FLT)
-      integer nRd, nFlt, nProb, nAmp(MAX_PROB)
-      integer iProb, iAtten, iFlt, iAmp, k
-      real lat, long, version
-      real segModelwt(MAX_FLT),al_segwt(MAX_FLT),
-     1     mindist(MAX_FLT),Haz(MAX_PROB,MAX_INTEN,MAX_FLT)
-      real HazTotal(MAX_PROB,MAX_INTEN), amp(MAX_PROB,MAX_INTEN)
-      real mBar(MAX_PROB,MAX_INTEN), dBar(MAX_PROB,MAX_INTEN),
-     1  eBar(MAX_PROB,MAX_INTEN)
-      real testHaz, x, UHS1(MAX_PROB)
 
 c     open the out3 file
       read (31,'( a80)') file1 
       write (*,'( a80)') file1
-c      pause 'in out3' 
       nRd = 23
       open (nRd,file=file1,status='old')
 
-C     Check for version compatibility with hazard code
+c     Check for version compatibility with hazard code
         read (nRd,*) version
          if (version .ne. 45.2) then
            write (*,*) 'out3 from incompatible version of Haz45, use Haz45.2'
@@ -48,9 +45,6 @@ c     Read in the hazard curves for all periods in given Haz45 ouptut file.
             read (nRD,'( 15x,i5)')  iAtten
             read (nRD,*) nAmp(iProb)
             read (nRD,'( 61x,30f12.4)') (amp(iProb,k),k=1,nAmp(iProb))
-            
-c            write(*,*) amp(iProb,1)
-c            pause 'amp'
 
             do l=1,nFlt
                read (nRD,'( 2x,a38,2f6.3,f8.1,1x,30e12.4)') fname(l),
@@ -69,7 +63,6 @@ c            pause 'amp'
                read (nRD,'( a80)') dummy
             enddo
             
-
          enddo
          close (nRD)
 

--- a/CMS_Files/rd_out3.f
+++ b/CMS_Files/rd_out3.f
@@ -19,8 +19,8 @@ c     open the out3 file
 
 c     Check for version compatibility with hazard code
         read (nRd,*) version
-         if (version .ne. 45.2) then
-           write (*,*) 'out3 from incompatible version of Haz45, use Haz45.2'
+         if (version .ne. 45.3 .and. version .ne. 45.2) then
+           write (*,*) 'out3 from incompatible version of Haz45, use Haz45.3 or Haz45.2'
            stop 99
          endif 
 c     Read the output 3 file, keeping the total hazard and the background 

--- a/CMS_Files/read_out6.f
+++ b/CMS_Files/read_out6.f
@@ -23,8 +23,8 @@ c     Open output file
 
 c     Check for version compatibility with hazard code
         read (nwr,*) version
-         if (version .ne. 45.2) then
-           write (*,*) 'out6 from incompatible version of Haz45, use Haz45.2'
+         if (version .ne. 45.3 .and. version .ne. 45.2) then
+           write (*,*) 'out6 from incompatible version of Haz45, use Haz45.3 or Haz45.2'
            stop 99
          endif      
 

--- a/CMS_Files/read_out6.f
+++ b/CMS_Files/read_out6.f
@@ -1,17 +1,16 @@
 c -------------------------------------------------------------------
 
       subroutine read_logichaz_out6 ( haz, nProb, nattenType, nAtten, nInten)
+     
       implicit none
       include 'cms.h'
 
-
       real*8 haz(MAX_PROB, MAX_ATTENTYPE, MAX_ATTEN, MAX_INTEN)
+      integer nInten, nProb, nattenType, nAtten(MAX_PROB,MAX_ATTENTYPE),
+     1        iProb, jType, iAtten, iProb1, jType1, iAtten1, j, nwr
       real version
-      integer nInten, nProb, nattenType, nAtten(MAX_PROB,MAX_ATTENTYPE)
-      integer iProb, jType, iAtten
-      integer iProb1, jType1, iAtten1
-      integer j, nwr, ifile
       character*80 file1
+      
       nwr = 12
                      
 c     Open output file
@@ -22,7 +21,7 @@ c     Open output file
       write (*,*) file1
       open (nwr,file=file1,status='old',ERR=2000)
 
-C     Check for version compatibility with hazard code
+c     Check for version compatibility with hazard code
         read (nwr,*) version
          if (version .ne. 45.2) then
            write (*,*) 'out6 from incompatible version of Haz45, use Haz45.2'


### PR DESCRIPTION
The main changes are the two fixes to bugs, which cause errors in the calculations and outputs when a larger / more complex case is run, and the addition of the negative jcalc capability. I ran the reference test and the output is the same. I also ran a CMS for a hazard file that had non ergodic ground motions and ~50 ground motion models. This was the need that drove me to modify the code, and the CMS output looks good for this case.